### PR TITLE
Save LFS bandwidth by removing mlmodels

### DIFF
--- a/ThreeDify/ThreeDify/Estimation/Pipeline/Processors/FCRN.mlmodel
+++ b/ThreeDify/ThreeDify/Estimation/Pipeline/Processors/FCRN.mlmodel
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f42851455ff324e21bf529799d839390a30e251c30dec2b131c3467ae97bae77
-size 254654396

--- a/ThreeDify/ThreeDify/Estimation/Pipeline/Processors/FastDepth.mlmodel
+++ b/ThreeDify/ThreeDify/Estimation/Pipeline/Processors/FastDepth.mlmodel
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a23ebbb9ae696182eedbd331ffe824e69c779679e25456dfb63b79694b6a2c0
-size 5413056

--- a/ThreeDify/ThreeDify/Estimation/Pipeline/Processors/Pydnet.mlmodel
+++ b/ThreeDify/ThreeDify/Estimation/Pipeline/Processors/Pydnet.mlmodel
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f280bbb938cb1602e3c4b83eb26352509eeb59aae06697ca6e2589ca63533fe
-size 7938955


### PR DESCRIPTION
Models can be downloaded from sources in readme.